### PR TITLE
Added simple window movement on unix

### DIFF
--- a/Source/UnixPanel.cpp
+++ b/Source/UnixPanel.cpp
@@ -198,3 +198,18 @@ void UnixPanel::pushButtonMaximize()
         showMaximized();
     }
 }
+
+void UnixPanel::mousePressEvent(QMouseEvent *evt)
+{
+    oldWindowPos = evt->globalPos();
+}
+
+void UnixPanel::mouseMoveEvent(QMouseEvent *evt)
+{
+    const QPoint delta = evt->globalPos() - oldWindowPos;
+    if (evt->pos().y() < 70)
+    {
+        move(x()+delta.x(), y()+delta.y());
+        oldWindowPos = evt->globalPos();
+    }
+}

--- a/Source/UnixPanel.h
+++ b/Source/UnixPanel.h
@@ -21,6 +21,7 @@ private:
     QStackedWidget *stack;
     QWidget *libraryPtr;
     QWidget *browserPtr;
+    QPoint oldWindowPos;
 
     TabLabel *activeTab;
     TabLabel *libraryTab;
@@ -28,6 +29,10 @@ private:
     TabLabel *modsTab;
     TabLabel *newsTab;
     TabLabel *browserTab;
+
+    void mousePressEvent(QMouseEvent *);
+    void mouseMoveEvent(QMouseEvent *);
+
 };
 
 #endif // UNIXPANEL


### PR DESCRIPTION
Clicking and dragging on the top bar now moves the window around on
unix platforms. It’s a fairly rudimentary implementation, but better
than nothing I hope.
