### PR TITLE
Remove warning in qmake

### DIFF
--- a/BorderlessWindow/QtWinMigrate.pri
+++ b/BorderlessWindow/QtWinMigrate.pri
@@ -23,7 +23,6 @@ win32 {
 contains(QT_MAJOR_VERSION, 5): QT += widgets gui-private
 
 SOURCES += \
-    QWinHost.cpp \
     $$PWD/QWinHost.cpp \
     $$PWD/QWinWidget.cpp \
     $$PWD/QWinWidget.cpp


### PR DESCRIPTION
This pull request solves the following qmake warning:

`WARNING: Failure to find: QWinHost.cpp`
