### PR TITLE
Fix dragging on unix

### DIFF
--- a/Source/UnixWindow.cpp
+++ b/Source/UnixWindow.cpp
@@ -42,16 +42,22 @@ void UnixWindow::closeWindow()
     this->close();
 }
 
-void UnixWindow::mousePressEvent(QMouseEvent* evt)
+void UnixWindow::mousePressEvent(QMouseEvent *evt)
 {
     oldWindowPos = evt->globalPos();
 }
 
-void UnixWindow::mouseMoveEvent(QMouseEvent* evt)
+void UnixWindow::mouseReleaseEvent(QMouseEvent *evt)
+{
+    dragging = false;
+}
+
+void UnixWindow::mouseMoveEvent(QMouseEvent *evt)
 {
     const QPoint delta = evt->globalPos() - oldWindowPos;
-    if (evt->pos().y() < 70)
+    if (evt->pos().y() < 70 || dragging)
     {
+        dragging = true;
         move(x() + delta.x(), y() + delta.y());
         oldWindowPos = evt->globalPos();
     }

--- a/Source/UnixWindow.h
+++ b/Source/UnixWindow.h
@@ -17,9 +17,11 @@ public:
 private:
     UnixPanel* mainPanel;
     QPoint oldWindowPos;
+    bool dragging;
 
-    void mousePressEvent(QMouseEvent*);
-    void mouseMoveEvent(QMouseEvent*);
+    void mousePressEvent(QMouseEvent *evt);
+    void mouseReleaseEvent(QMouseEvent *evt);
+    void mouseMoveEvent(QMouseEvent *evt);
 };
 
 #endif // UNIXWINDOW


### PR DESCRIPTION
Previously, if the mouse went below 70px from the top of the window, the dragging operation would stop. This was because of a check that was put in place to prevent dragging by moving the mouse anywhere.

To fix this, a boolean was added which will be set to true on the first click and drag on the 70px area. If the boolean is true, then it will drag until the mouse is released.

This has been tested on Linux (Ubuntu 14.04 Unity) and it does not break Windows compilation.
