### PR TITLE
Add basic application running

### DIFF
--- a/Source/Library.cpp
+++ b/Source/Library.cpp
@@ -1,5 +1,6 @@
 #include <QFileDialog>
 #include <QProcess>
+#include <QMessageBox>
 
 #include "Library.h"
 #include "ui_Library.h"
@@ -10,11 +11,16 @@ Library::Library(QWidget *parent) :
 {
     ui->setupUi(this);
     this->setObjectName("libraryUI");
+    runningProcess = new QProcess(this);
+    processRunning = false;
+    connect(runningProcess, SIGNAL(finished(int, QProcess::ExitStatus)), this, SLOT(finished(int, QProcess::ExitStatus)));
+
 }
 
 Library::~Library()
 {
     delete ui;
+    delete runningProcess;
 }
 
 void Library::on_testLaunch_clicked()
@@ -23,18 +29,32 @@ void Library::on_testLaunch_clicked()
     dialog.setWindowTitle("Select Executable");
     dialog.setFileMode(QFileDialog::ExistingFile);
 
-
     if (dialog.exec()) {
         QStringList files = dialog.selectedFiles();
         QString file = files.at(0);
-
+#ifdef Q_WS_MACX
+        //Get the binary from the app bundle
+        QDir dir(file + "/Contents/MacOS");
+        QStringList fileList = dir.entryList();
+        file = dir.absoluteFilePath(fileList.at(2));//USUALLY this is the executable (after ., ..)
+#endif
         runProcess(file);
     }
 }
 
 void Library::runProcess(QString location) {
     // TODO: Implement some threading
-    QProcess process(this);
-    process.start("\"" + location + "\"");
-    process.waitForFinished(-1);
+    if (!processRunning) {
+        runningProcess->start(location);
+        runningProcess->waitForStarted();
+        processRunning = true;
+    } else {
+        QMessageBox messageBox(this);
+        messageBox.setText("Error: an application is already running.");
+        messageBox.exec();
+    }
+}
+
+void Library::finished(int exitcode, QProcess::ExitStatus exitstatus) {
+    processRunning = false;
 }

--- a/Source/Library.cpp
+++ b/Source/Library.cpp
@@ -27,7 +27,7 @@ void Library::on_testLaunch_clicked()
 {
 
     if (!processRunning) {
-        QFileDialog dialog();
+        QFileDialog dialog;
         dialog.setWindowTitle("Select Executable");
         dialog.setFileMode(QFileDialog::ExistingFile);
 
@@ -43,7 +43,7 @@ void Library::on_testLaunch_clicked()
             runProcess(file);
         }
     } else {
-        QMessageBox messageBox();
+        QMessageBox messageBox;
         messageBox.setText("Error: an application is already running.");
         messageBox.exec();
     }

--- a/Source/Library.cpp
+++ b/Source/Library.cpp
@@ -25,20 +25,27 @@ Library::~Library()
 
 void Library::on_testLaunch_clicked()
 {
-    QFileDialog dialog(this);
-    dialog.setWindowTitle("Select Executable");
-    dialog.setFileMode(QFileDialog::ExistingFile);
 
-    if (dialog.exec()) {
-        QStringList files = dialog.selectedFiles();
-        QString file = files.at(0);
-#ifdef Q_WS_MACX
-        //Get the binary from the app bundle
-        QDir dir(file + "/Contents/MacOS");
-        QStringList fileList = dir.entryList();
-        file = dir.absoluteFilePath(fileList.at(2));//USUALLY this is the executable (after ., ..)
-#endif
-        runProcess(file);
+    if (!processRunning) {
+        QFileDialog dialog();
+        dialog.setWindowTitle("Select Executable");
+        dialog.setFileMode(QFileDialog::ExistingFile);
+
+        if (dialog.exec()) {
+            QStringList files = dialog.selectedFiles();
+            QString file = files.at(0);
+            #ifdef Q_WS_MACX
+                //Get the binary from the app bundle
+                QDir dir(file + "/Contents/MacOS");
+                QStringList fileList = dir.entryList();
+                file = dir.absoluteFilePath(fileList.at(2));//USUALLY this is the executable (after ., ..)
+            #endif
+            runProcess(file);
+        }
+    } else {
+        QMessageBox messageBox();
+        messageBox.setText("Error: an application is already running.");
+        messageBox.exec();
     }
 }
 
@@ -48,10 +55,6 @@ void Library::runProcess(QString location) {
         runningProcess->start(location);
         runningProcess->waitForStarted();
         processRunning = true;
-    } else {
-        QMessageBox messageBox(this);
-        messageBox.setText("Error: an application is already running.");
-        messageBox.exec();
     }
 }
 

--- a/Source/Library.h
+++ b/Source/Library.h
@@ -2,6 +2,7 @@
 #define LIBRARY_H
 
 #include <QWidget>
+#include <QProcess>
 
 namespace Ui {
 class Library;
@@ -17,9 +18,12 @@ public:
 
 private slots:
     void on_testLaunch_clicked();
+    void finished(int exitcode, QProcess::ExitStatus exitStatus);
 
 private:
     Ui::Library *ui;
+    QProcess *runningProcess;
+    bool processRunning;
 
     void runProcess(QString file);
 };


### PR DESCRIPTION
Use QProcess to run applications. At the moment, it only allows for one application at a time to be running, and the running application runs in its own thread but can be asynchronously accessed by the launcher. On OS X, it searchs the .app/Contents/Mac OS/ folder for the binary, and on other platforms it simply runs the executable the user has selected.
