### PR TITLE
Fix various issues I've encountered

### DIFF
--- a/Source/Library.cpp
+++ b/Source/Library.cpp
@@ -15,7 +15,6 @@ Library::Library(Database db) :
     ui->setupUi(this);
     this->setObjectName("libraryUI");
     runningProcess = new QProcess(this);
-    processRunning = false;
     connect(runningProcess, SIGNAL(finished(int, QProcess::ExitStatus)), this, SLOT(finished(int, QProcess::ExitStatus)));
 
     QList<Game> games = db.getGames();
@@ -35,7 +34,7 @@ Library::~Library()
 
 void Library::on_testLaunch_clicked()
 {
-    if (!processRunning)
+    if (!isProcessRunning())
     {
         Game game = db.getGameByName(ui->gameListWidget->item(ui->gameListWidget->currentRow())->text());
         runProcess(game.executablePath, game.gameDirectory);
@@ -100,7 +99,7 @@ void Library::on_removeGame_clicked()
 void Library::runProcess(QString file, QString workingDirectory)
 {
     // TODO: Implement some threading
-    if (!processRunning)
+    if (!isProcessRunning())
     {
         qDebug() << "Launching:" << file << ", at" << workingDirectory;
         runningProcess->setWorkingDirectory(workingDirectory);
@@ -108,7 +107,6 @@ void Library::runProcess(QString file, QString workingDirectory)
         runningProcess->setStandardOutputFile("log.txt");
         runningProcess->start("\"" + file + "\"");
         runningProcess->waitForStarted();
-        processRunning = true;
     }
 }
 
@@ -124,5 +122,10 @@ void Library::refreshGames()
 
 void Library::finished(int exitCode, QProcess::ExitStatus exitStatus)
 {
-    processRunning = false;
+}
+
+bool Library::isProcessRunning() const
+{
+    // We shall consider "Starting" to be running here too
+    return runningProcess->state() != QProcess::NotRunning;
 }

--- a/Source/Library.cpp
+++ b/Source/Library.cpp
@@ -16,6 +16,7 @@ Library::Library(Database db) :
     ui->setupUi(this);
     this->setObjectName("libraryUI");
     connect(runningProcess, SIGNAL(finished(int, QProcess::ExitStatus)), this, SLOT(finished(int, QProcess::ExitStatus)));
+    connect(runningProcess, SIGNAL(error(QProcess::ProcessError)), this, SLOT(onLaunchError(QProcess::ProcessError)));
 
     QList<Game> games = db.getGames();
     for (auto game : games)
@@ -122,6 +123,26 @@ void Library::refreshGames()
 
 void Library::finished(int exitCode, QProcess::ExitStatus exitStatus)
 {
+    if (exitCode != 0)
+    {
+        QMessageBox(QMessageBox::Warning, "Warning", "The game finished, but it claims to have encountered an error").exec();
+    }
+}
+
+void Library::onLaunchError(QProcess::ProcessError error)
+{
+    switch (error)
+    {
+        case QProcess::FailedToStart:
+            QMessageBox(QMessageBox::Critical, "Error", "Could not start the game. Please double check that you are using the correct file to launch it.").exec();
+            break;
+        case QProcess::Crashed:
+            QMessageBox(QMessageBox::Warning, "Crash!", "The launched game has crashed").exec();
+            break;
+        default:
+            // Other cases are errors unrelated to startup, so let's not handle them
+            break;
+    }
 }
 
 bool Library::isProcessRunning() const

--- a/Source/Library.cpp
+++ b/Source/Library.cpp
@@ -106,7 +106,7 @@ void Library::runProcess(QString file, QString workingDirectory)
         runningProcess->setWorkingDirectory(workingDirectory);
         runningProcess->setStandardErrorFile("error.txt");
         runningProcess->setStandardOutputFile("log.txt");
-        runningProcess->start("\"" + file + "\"");
+        runningProcess->start(file, QStringList());
         runningProcess->waitForStarted();
     }
 }

--- a/Source/Library.cpp
+++ b/Source/Library.cpp
@@ -37,8 +37,12 @@ void Library::on_testLaunch_clicked()
 {
     if (!isProcessRunning())
     {
-        Game game = db.getGameByName(ui->gameListWidget->item(ui->gameListWidget->currentRow())->text());
-        runProcess(game.executablePath, game.gameDirectory);
+        auto selection = ui->gameListWidget->currentItem();
+        if (selection != nullptr)
+        {
+            Game game = db.getGameByName(selection->text());
+            runProcess(game.executablePath, game.gameDirectory);
+        }
     }
     else
     {
@@ -93,8 +97,12 @@ void Library::on_addGame_clicked()
 
 void Library::on_removeGame_clicked()
 {
-    db.removeGameByName(ui->gameListWidget->item(ui->gameListWidget->currentRow())->text());
-    refreshGames();
+    auto selection = ui->gameListWidget->currentItem();
+    if (selection != nullptr)
+    {
+        db.removeGameByName(selection->text());
+        refreshGames();
+    }
 }
 
 void Library::runProcess(QString file, QString workingDirectory)

--- a/Source/Library.cpp
+++ b/Source/Library.cpp
@@ -10,11 +10,11 @@
 Library::Library(Database db) :
     QWidget(0),
     db(db),
-    ui(new Ui::Library)
+    ui(new Ui::Library),
+    runningProcess(new QProcess(this))
 {
     ui->setupUi(this);
     this->setObjectName("libraryUI");
-    runningProcess = new QProcess(this);
     connect(runningProcess, SIGNAL(finished(int, QProcess::ExitStatus)), this, SLOT(finished(int, QProcess::ExitStatus)));
 
     QList<Game> games = db.getGames();

--- a/Source/Library.h
+++ b/Source/Library.h
@@ -29,8 +29,8 @@ private:
     Database db;
     Ui::Library* ui;
     QProcess* runningProcess;
-    bool processRunning;
 
+    bool isProcessRunning() const;
     void runProcess(QString file, QString workingDirectory);
     void refreshGames();
 };

--- a/Source/Library.h
+++ b/Source/Library.h
@@ -22,6 +22,7 @@ private slots:
     void on_testLaunch_clicked();
     void on_addGame_clicked();
     void finished(int exitCode, QProcess::ExitStatus exitStatus);
+    void onLaunchError(QProcess::ProcessError error);
 
     void on_removeGame_clicked();
 


### PR DESCRIPTION
This will probably need some testing (7104e82 especially; tested on linux only). It is intended to fix some issues I've found:
- Crash on removing/running game when none is selected
- No further games can be launched after trying to launch a game that can't be run. (Tested with a .png file [not an executable])
- Games with odd filenames don't work (Tested with '/home/score/te"s t', an executable script which calls zenity to show me that it worked)
- No indication if something fails (e.g. /bin/false) or crashes (`main(){*(int*)0=0;}`). If something crashes early, I let the user know about it, rather than leading them to think it is just loading extraordinarily slowly. Probably less of a problem if you have those error report dialogs enabled in your OS.
