### PR TITLE
Fix for an Aero Problem on Windows 7

### DIFF
--- a/Source/BorderlessWindow.cpp
+++ b/Source/BorderlessWindow.cpp
@@ -19,7 +19,7 @@ BorderlessWindow::BorderlessWindow(QApplication* app, HBRUSH windowBackground, c
     visible(false),
     borderless(false),
     borderlessResizeable(true),
-    aeroShadow(false)
+    aeroShadow(true)
 {
     WNDCLASSEX wcx = {0};
     wcx.cbSize = sizeof(WNDCLASSEX);


### PR DESCRIPTION
1 pixel border that's affected by Aero.

Before: https://i.imgur.com/8HB3XiP.png
After: https://i.imgur.com/7p5naHl.png

Tested on Windows 7 Home Premium 64 Bit.
