### PR TITLE
CMake patch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ qt5_add_resources(UI_RESOURCES ${RESOURCES})
 include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}
     ${Qt5Gui_INCLUDE_DIRS}
+    ${Qt5Gui_PRIVATE_INCLUDE_DIRS}
     ${Qt5Widgets_INCLUDE_DIRS}
     ${Qt5Core_INCLUDE_DIRS}
     ${Qt5Network_INCLUDE_DIRS}


### PR DESCRIPTION
I added `${Qt5Gui_PRIVATE_INCLUDE_DIRS}` to CMakeLists.txt because GCC on
[MSYS2 (MinGW-w64)](https://msys2.github.io/) can't find `qpa/qplatformnativeinterface.h` showing
this error:

```
fatal error: qpa/qplatformnativeinterface.h: No such file or directory
```
