### PR TITLE
Find origin games, refactor the find a bit

### DIFF
--- a/Source/Library.cpp
+++ b/Source/Library.cpp
@@ -27,13 +27,16 @@ Library::Library(Database db)
 {
     ui->setupUi(this);
     this->setObjectName("libraryUI");
-    connect(runningProcess, SIGNAL(finished(int, QProcess::ExitStatus)), this, SLOT(finished(int, QProcess::ExitStatus)));
-    connect(runningProcess, SIGNAL(error(QProcess::ProcessError)), this, SLOT(onLaunchError(QProcess::ProcessError)));
+    connect(runningProcess, SIGNAL(finished(int, QProcess::ExitStatus)), this,
+            SLOT(finished(int, QProcess::ExitStatus)));
+    connect(runningProcess, SIGNAL(error(QProcess::ProcessError)), this,
+            SLOT(onLaunchError(QProcess::ProcessError)));
 
     QList<Game> games = db.getGames();
     for (auto game : games)
     {
-        qDebug() << game.id << game.gameName << game.gameDirectory << game.executablePath;
+        qDebug() << game.id << game.gameName << game.gameDirectory
+                 << game.executablePath;
     }
 
     refreshGames();
@@ -51,7 +54,8 @@ Library::Library(Database db)
     QDir steamRoot;
     steamRoot.setPath("");
 #if defined(_WIN32) || defined(_WIN64)
-    QSettings settings("HKEY_CURRENT_USER\\Software\\Valve\\Steam", QSettings::NativeFormat);
+    QSettings settings("HKEY_CURRENT_USER\\Software\\Valve\\Steam",
+                       QSettings::NativeFormat);
     QString steamPath = settings.value("SteamPath").toString();
     steamRoot = QDir(steamPath);
 #elif defined(__APPLE__)
@@ -60,7 +64,8 @@ Library::Library(Database db)
 #elif defined(__linux__)
     steamRoot = QDir(QDir::home().filePath(".steam/steam"));
 #else
-    QMessageBox(QMessageBox::Critical, "Error", "Platform doesn't support steam.");
+    QMessageBox(QMessageBox::Critical, "Error",
+                "Platform doesn't support steam.");
     return;
 #endif
 
@@ -124,14 +129,15 @@ void Library::on_addGame_clicked()
         QStringList files = exeDialog.selectedFiles();
         QString exe = files.at(0);
 #ifdef Q_WS_MACX
-        //Get the binary from the app bundle
+        // Get the binary from the app bundle
         QDir dir(file + "/Contents/MacOS");
         // TODO: Change to dir.entryList(QDir::NoDotAndDotDot) to be safe
         QStringList fileList = dir.entryList();
-        file = dir.absoluteFilePath(fileList.at(2));// USUALLY this is the executable (after ., ..)
+        file = dir.absoluteFilePath(
+            fileList.at(2));  // USUALLY this is the executable (after ., ..)
 #endif
 
-        QFileDialog wdDialog; // Working Directory
+        QFileDialog wdDialog;  // Working Directory
         wdDialog.setWindowTitle("Select Working Directory");
         wdDialog.setFileMode(QFileDialog::DirectoryOnly);
         wdDialog.setDirectory(exeDialog.directory().absolutePath());
@@ -187,7 +193,10 @@ void Library::finished(int exitCode, QProcess::ExitStatus exitStatus)
 {
     if (exitCode != 0)
     {
-        QMessageBox(QMessageBox::Warning, "Warning", "The game finished, but it claims to have encountered an error").exec();
+        QMessageBox(
+            QMessageBox::Warning, "Warning",
+            "The game finished, but it claims to have encountered an error")
+            .exec();
     }
 }
 
@@ -195,15 +204,22 @@ void Library::onLaunchError(QProcess::ProcessError error)
 {
     switch (error)
     {
-    case QProcess::FailedToStart:
-        QMessageBox(QMessageBox::Critical, "Error", "Could not start the game. Please double check that you are using the correct file to launch it.").exec();
-        break;
-    case QProcess::Crashed:
-        QMessageBox(QMessageBox::Warning, "Crash!", "The launched game has crashed").exec();
-        break;
-    default:
-        // Other cases are errors unrelated to startup, so let's not handle them
-        break;
+        case QProcess::FailedToStart:
+            QMessageBox(
+                QMessageBox::Critical, "Error",
+                "Could not start the game. Please double check that you are "
+                "using the correct file to launch it.")
+                .exec();
+            break;
+        case QProcess::Crashed:
+            QMessageBox(QMessageBox::Warning, "Crash!",
+                        "The launched game has crashed")
+                .exec();
+            break;
+        default:
+            // Other cases are errors unrelated to startup, so let's not handle
+            // them
+            break;
     }
 }
 
@@ -216,7 +232,10 @@ bool Library::isProcessRunning() const
 void Library::findSteamGames(QDir steamRoot)
 {
     pt::ptree libraryFolders;
-    pt::read_info(steamRoot.filePath("steamapps/libraryfolders.vdf").toLocal8Bit().constData(), libraryFolders);
+    pt::read_info(steamRoot.filePath("steamapps/libraryfolders.vdf")
+                      .toLocal8Bit()
+                      .constData(),
+                  libraryFolders);
     steamDirectoryList.append(steamRoot.filePath(""));
     QString pathString = "" + steamDirectoryList.at(0) + "\n";
 
@@ -237,16 +256,24 @@ void Library::findSteamGames(QDir steamRoot)
 
     // TODO: Make this prompting better/less obtrusive
     bool directoryPlural = (steamDirectoryList.size() > 1);
-    int ret = QMessageBox(QMessageBox::Question, "Found " + QString::number(steamDirectoryList.size()) + " director" + (directoryPlural ? "ies" : "y"), QString::number(steamDirectoryList.size()) + " directories have been found.\n\n" + pathString + "Proceed?", QMessageBox::Yes | QMessageBox::No).exec();
+    int ret =
+        QMessageBox(QMessageBox::Question,
+                    "Found " + QString::number(steamDirectoryList.size()) +
+                        " director" + (directoryPlural ? "ies" : "y"),
+                    QString::number(steamDirectoryList.size()) +
+                        " directories have been found.\n\n" + pathString +
+                        "Proceed?",
+                    QMessageBox::Yes | QMessageBox::No)
+            .exec();
     switch (ret)
     {
-    case QMessageBox::Yes:
-        parseAcf();
-        break;
-    case QMessageBox::No:
-        break;
-    default:
-        break;
+        case QMessageBox::Yes:
+            parseAcf();
+            break;
+        case QMessageBox::No:
+            break;
+        default:
+            break;
     }
 }
 
@@ -254,25 +281,39 @@ void Library::findOriginGames(QDir originRoot)
 {
     QDir originFolder;
     pt::ptree originTree;
-    read_xml(originRoot.filePath("local.xml").toLocal8Bit().constData(), originTree);
+    read_xml(originRoot.filePath("local.xml").toLocal8Bit().constData(),
+             originTree);
     for (auto& xmlIter : originTree.get_child("Settings"))
     {
-        if (xmlIter.second.get<std::string>("<xmlattr>.key") == "DownloadInPlaceDir")
+        if (xmlIter.second.get<std::string>("<xmlattr>.key") ==
+            "DownloadInPlaceDir")
         {
-            originFolder = QString::fromStdString(xmlIter.second.get<std::string>("<xmlattr>.value"));
+            originFolder = QString::fromStdString(
+                xmlIter.second.get<std::string>("<xmlattr>.value"));
             qDebug() << originFolder;
             break;
         }
     }
 
     QStringList ignoreList;
-    ignoreList << "Cleanup.exe" << "Touchup.exe" << "DXSETUP.exe" << "vcredist_x86.exe" << "vcredist_x64.exe" << "ActivationUI.exe" << "PatchProgress.exe" << "activation.exe" << "EACoreServer.exe" << "EAProxyInstaller.exe" << "D3D11Install.exe";
-    originFolder.setFilter(QDir::Dirs | QDir::NoDotAndDotDot | QDir::NoSymLinks);
+    ignoreList << "Cleanup.exe"
+               << "Touchup.exe"
+               << "DXSETUP.exe"
+               << "vcredist_x86.exe"
+               << "vcredist_x64.exe"
+               << "ActivationUI.exe"
+               << "PatchProgress.exe"
+               << "activation.exe"
+               << "EACoreServer.exe"
+               << "EAProxyInstaller.exe"
+               << "D3D11Install.exe";
+    originFolder.setFilter(QDir::Dirs | QDir::NoDotAndDotDot |
+                           QDir::NoSymLinks);
     QStringList folderList = originFolder.entryList();
     QHash<QString, QStringList> masterList;
     for (auto i : folderList)
     {
-        //TODO: Populate a widget with this info
+        // TODO: Populate a widget with this info
         QDir dir(originFolder.absoluteFilePath(i));
         dir.setNameFilters(QStringList("*.exe"));
         dir.setFilter(QDir::Files | QDir::NoDotAndDotDot | QDir::NoSymLinks);
@@ -329,19 +370,25 @@ void Library::parseAcf()
     {
         QDir steamAppsDir(iter);
         steamAppsDir = steamAppsDir.filePath("steamapps");
-        QStringList fileList = steamAppsDir.entryList(QStringList("*.acf"), QDir::Files | QDir::NoSymLinks);
+        QStringList fileList = steamAppsDir.entryList(
+            QStringList("*.acf"), QDir::Files | QDir::NoSymLinks);
 
         for (auto fileIter : fileList)
         {
             pt::ptree fileTree;
-            std::string acfDir = steamAppsDir.filePath(fileIter).toLocal8Bit().constData();
+            std::string acfDir =
+                steamAppsDir.filePath(fileIter).toLocal8Bit().constData();
             pt::read_info(acfDir, fileTree);
 
-            QString name = QString::fromStdString(fileTree.get<std::string>("AppState.name"));
+            QString name = QString::fromStdString(
+                fileTree.get<std::string>("AppState.name"));
             // TODO: Either add SteamID to db, or add getGameByPath
-            QString path = steamAppsDir.filePath("common/" + QString::fromStdString(fileTree.get<std::string>("AppState.installdir")));
+            QString path = steamAppsDir.filePath(
+                "common/" + QString::fromStdString(fileTree.get<std::string>(
+                                "AppState.installdir")));
             QString exe;
-            QStringList exeList = QDir(path).entryList(QDir::Files | QDir::NoSymLinks | QDir::Executable);
+            QStringList exeList = QDir(path).entryList(
+                QDir::Files | QDir::NoSymLinks | QDir::Executable);
 
             QFileDialog exeDialog;
             exeDialog.setWindowTitle("Select Executable");

--- a/Source/Library.cpp
+++ b/Source/Library.cpp
@@ -383,7 +383,6 @@ void Library::parseAcf()
             QString name = QString::fromStdString(
                 fileTree.get<std::string>("AppState.name"));
             // TODO: Either add SteamID to db, or add getGameByPath
-=======
             if (!std::get<0>(db.isExistant(name)))
             {
                 QString path = steamAppsDir.filePath("common/" + QString::fromStdString(fileTree.get<std::string>("AppState.installdir")));

--- a/Source/Library.cpp
+++ b/Source/Library.cpp
@@ -1,15 +1,15 @@
 #include "Library.h"
 #include "ui_Library.h"
 
-
 #include <QFileDialog>
 #include <QInputDialog>
-#include <QProcess>
 #include <QMessageBox>
 #include <QDebug>
+#include <QDirIterator>
 
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/info_parser.hpp>
+#include <boost/property_tree/xml_parser.hpp>
 
 #include <cctype>
 
@@ -37,7 +37,42 @@ Library::Library(Database db)
     }
 
     refreshGames();
-    findSteamGames();
+    QDir originRoot(qgetenv("APPDATA").append("/Origin"));
+    if (originRoot.exists())
+    {
+        findOriginGames(originRoot);
+    }
+    else
+    {
+        qDebug() << "Origin not found. Possibly not installed.";
+    }
+
+    bool steamFound = true;
+    QDir steamRoot;
+    steamRoot.setPath("");
+#if defined(_WIN32) || defined(_WIN64)
+    QSettings settings("HKEY_CURRENT_USER\\Software\\Valve\\Steam", QSettings::NativeFormat);
+    QString steamPath = settings.value("SteamPath").toString();
+    steamRoot = QDir(steamPath);
+#elif defined(__APPLE__)
+    // TODO: however OS X handles steam
+    return;
+#elif defined(__linux__)
+    steamRoot = QDir(QDir::home().filePath(".steam/steam"));
+#else
+    QMessageBox(QMessageBox::Critical, "Error", "Platform doesn't support steam.");
+    return;
+#endif
+
+    if (steamRoot.exists() && steamFound)
+    {
+        findSteamGames(steamRoot);
+    }
+    else
+    {
+        qDebug("Steam was not found, probably not installed.");
+        steamFound = false;
+    }
 }
 
 Library::~Library()
@@ -78,23 +113,23 @@ void Library::on_addGame_clicked()
     QFileDialog exeDialog;
     exeDialog.setWindowTitle("Select Executable");
     exeDialog.setFileMode(QFileDialog::ExistingFile);
-    #if defined(__unix__)
-        exeDialog.setDirectory(QDir::home());
-    #elif defined(_WIN32) || defined(_WIN64)
-        exeDialog.setDirectory("C:");
-    #endif
+#if defined(__unix__)
+    exeDialog.setDirectory(QDir::home());
+#elif defined(_WIN32) || defined(_WIN64)
+    exeDialog.setDirectory("C:");
+#endif
 
     if (exeDialog.exec())
     {
         QStringList files = exeDialog.selectedFiles();
         QString exe = files.at(0);
-        #ifdef Q_WS_MACX
-            //Get the binary from the app bundle
-            QDir dir(file + "/Contents/MacOS");
-            // TODO: Change to dir.entryList(QDir::NoDotAndDotDot) to be safe
-            QStringList fileList = dir.entryList();
-            file = dir.absoluteFilePath(fileList.at(2));// USUALLY this is the executable (after ., ..)
-        #endif
+#ifdef Q_WS_MACX
+        //Get the binary from the app bundle
+        QDir dir(file + "/Contents/MacOS");
+        // TODO: Change to dir.entryList(QDir::NoDotAndDotDot) to be safe
+        QStringList fileList = dir.entryList();
+        file = dir.absoluteFilePath(fileList.at(2));// USUALLY this is the executable (after ., ..)
+#endif
 
         QFileDialog wdDialog; // Working Directory
         wdDialog.setWindowTitle("Select Working Directory");
@@ -160,15 +195,15 @@ void Library::onLaunchError(QProcess::ProcessError error)
 {
     switch (error)
     {
-        case QProcess::FailedToStart:
-            QMessageBox(QMessageBox::Critical, "Error", "Could not start the game. Please double check that you are using the correct file to launch it.").exec();
-            break;
-        case QProcess::Crashed:
-            QMessageBox(QMessageBox::Warning, "Crash!", "The launched game has crashed").exec();
-            break;
-        default:
-            // Other cases are errors unrelated to startup, so let's not handle them
-            break;
+    case QProcess::FailedToStart:
+        QMessageBox(QMessageBox::Critical, "Error", "Could not start the game. Please double check that you are using the correct file to launch it.").exec();
+        break;
+    case QProcess::Crashed:
+        QMessageBox(QMessageBox::Warning, "Crash!", "The launched game has crashed").exec();
+        break;
+    default:
+        // Other cases are errors unrelated to startup, so let's not handle them
+        break;
     }
 }
 
@@ -178,72 +213,119 @@ bool Library::isProcessRunning() const
     return runningProcess->state() != QProcess::NotRunning;
 }
 
-void Library::findSteamGames()
+void Library::findSteamGames(QDir steamRoot)
 {
-    bool steamFound = true;
-    QDir steamRoot;
-    steamRoot.setPath("");
-    #if defined(_WIN32) || defined(_WIN64)
-        QSettings settings("HKEY_CURRENT_USER\\Software\\Valve\\Steam", QSettings::NativeFormat);
-        QString steamPath = settings.value("SteamPath").toString();
-        if (steamPath.trimmed() == "")
-        {
-            qDebug("Steam was not found, probably not installed.");
-            steamFound = false;
-        }
-        steamRoot = QDir(steamPath);
-    #elif defined(__APPLE__)
-        // TODO: however OS X handles steam
-        return;
-    #elif defined(__linux__)
-        steamRoot = QDir(QDir::home().filePath(".steam/steam"));
-    #else
-        QMessageBox(QMessageBox::Critical, "Error", "Platform doesn't support steam.");
-        return;
-    #endif
+    pt::ptree libraryFolders;
+    pt::read_info(steamRoot.filePath("steamapps/libraryfolders.vdf").toLocal8Bit().constData(), libraryFolders);
+    steamDirectoryList.append(steamRoot.filePath(""));
+    QString pathString = "" + steamDirectoryList.at(0) + "\n";
 
-    if (steamRoot.exists() && steamFound)
+    for (auto kv : libraryFolders.get_child("LibraryFolders"))
     {
-        pt::ptree libraryFolders;
-        pt::read_info(steamRoot.filePath("steamapps/libraryfolders.vdf").toLocal8Bit().constData(), libraryFolders);
-        steamDirectoryList.append(steamRoot.filePath(""));
-        QString pathString = "" + steamDirectoryList.at(0) + "\n";
-
-        for (auto kv : libraryFolders.get_child("LibraryFolders"))
+        if (std::isdigit(static_cast<int>(*kv.first.data())))
         {
-            if (std::isdigit(static_cast<int>(*kv.first.data())))
+            std::string path = kv.second.data();
+            QDir dir(QString::fromStdString(path));
+            if (dir.exists())
             {
-                std::string path = kv.second.data();
-                QDir dir(QString::fromStdString(path));
-                if (dir.exists())
-                {
-                    steamDirectoryList.append(dir.filePath(""));
-                    pathString += dir.filePath("");
-                    pathString += "\n";
-                }
+                steamDirectoryList.append(dir.filePath(""));
+                pathString += dir.filePath("");
+                pathString += "\n";
             }
         }
+    }
 
-        // TODO: Make this prompting better/less obtrusive
-        bool directoryPlural = (steamDirectoryList.size() > 1);
-        int ret = QMessageBox(QMessageBox::Question, "Found " + QString::number(steamDirectoryList.size()) + " director" + (directoryPlural ? "ies" : "y"), QString::number(steamDirectoryList.size()) + " directories have been found.\n\n" + pathString + "Proceed?", QMessageBox::Yes | QMessageBox::No).exec();
-        switch(ret)
+    // TODO: Make this prompting better/less obtrusive
+    bool directoryPlural = (steamDirectoryList.size() > 1);
+    int ret = QMessageBox(QMessageBox::Question, "Found " + QString::number(steamDirectoryList.size()) + " director" + (directoryPlural ? "ies" : "y"), QString::number(steamDirectoryList.size()) + " directories have been found.\n\n" + pathString + "Proceed?", QMessageBox::Yes | QMessageBox::No).exec();
+    switch (ret)
+    {
+    case QMessageBox::Yes:
+        parseAcf();
+        break;
+    case QMessageBox::No:
+        break;
+    default:
+        break;
+    }
+}
+
+void Library::findOriginGames(QDir originRoot)
+{
+    QDir originFolder;
+    pt::ptree originTree;
+    read_xml(originRoot.filePath("local.xml").toLocal8Bit().constData(), originTree);
+    for (auto& xmlIter : originTree.get_child("Settings"))
+    {
+        if (xmlIter.second.get<std::string>("<xmlattr>.key") == "DownloadInPlaceDir")
         {
-            case QMessageBox::Yes:
-                parseAcf();
-                break;
-            case QMessageBox::No:
-                break;
-            default:
-                break;
+            originFolder = QString::fromStdString(xmlIter.second.get<std::string>("<xmlattr>.value"));
+            qDebug() << originFolder;
+            break;
         }
     }
+
+    QStringList ignoreList;
+    ignoreList << "Cleanup.exe" << "Touchup.exe" << "DXSETUP.exe" << "vcredist_x86.exe" << "vcredist_x64.exe" << "ActivationUI.exe" << "PatchProgress.exe" << "activation.exe" << "EACoreServer.exe" << "EAProxyInstaller.exe" << "D3D11Install.exe";
+    originFolder.setFilter(QDir::Dirs | QDir::NoDotAndDotDot | QDir::NoSymLinks);
+    QStringList folderList = originFolder.entryList();
+    QHash<QString, QStringList> masterList;
+    for (auto i : folderList)
+    {
+        //TODO: Populate a widget with this info
+        QDir dir(originFolder.absoluteFilePath(i));
+        dir.setNameFilters(QStringList("*.exe"));
+        dir.setFilter(QDir::Files | QDir::NoDotAndDotDot | QDir::NoSymLinks);
+        qDebug() << "Looking in: " << dir.filePath("");
+        QStringList test = recursiveFindFiles(dir, ignoreList);
+        masterList.insert(dir.filePath(""), test);
+    }
+
+    QHashIterator<QString, QStringList> masterIter(masterList);
+    while (masterIter.hasNext())
+    {
+        masterIter.next();
+        qDebug() << "Found in: " << masterIter.key();
+        for (auto fileIter : masterIter.value())
+        {
+            qDebug() << fileIter;
+        }
+    }
+}
+
+QStringList Library::recursiveFindFiles(QDir dir, QStringList ignoreList)
+{
+    QStringList dirList;
+    QDirIterator it(dir, QDirIterator::Subdirectories);
+
+    while (it.hasNext())
+    {
+        QDir cur = it.next();
+        if (!ignoreList.contains(cur.dirName()))
+        {
+            bool found = false;
+            for (auto foundIter : dirList)
+            {
+                if (QDir(foundIter).dirName() == cur.dirName())
+                {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found)
+            {
+                dirList.append(cur.filePath(""));
+            }
+        }
+    }
+
+    return dirList;
 }
 
 void Library::parseAcf()
 {
     // TODO: This stuff needs its own thread
-    for(QString iter : steamDirectoryList)
+    for (QString iter : steamDirectoryList)
     {
         QDir steamAppsDir(iter);
         steamAppsDir = steamAppsDir.filePath("steamapps");

--- a/Source/Library.h
+++ b/Source/Library.h
@@ -4,6 +4,7 @@
 
 #include <QWidget>
 #include <QProcess>
+#include <QDir>
 
 namespace Ui
 {
@@ -33,8 +34,10 @@ private:
     QList<QString> steamDirectoryList;
 
     bool isProcessRunning() const;
+    QStringList recursiveFindFiles(QDir dir, QStringList ignoreList);
     void runProcess(QString file, QString workingDirectory);
     void refreshGames();
-    void findSteamGames();
+    void findSteamGames(QDir steamRoot);
+    void findOriginGames(QDir originRoot);
     void parseAcf();
 };


### PR DESCRIPTION
- I moved the checking for steam/origin out of the functions as a precursor to the final workflow
- Added a recursiveFindFiles which could do with its own thread but for now it's plenty fast
- For testing, there's a masterList QHash for each directory in originRoot arranged by directory:listOfExecutables (this will become the populated checkbox)
- Removed as it's not necessary to explicitly include it, due to being included in Library.h too

Anything I've done stupidly, let me know.
