### PR TITLE
Fix crash when steam is not installed on Windows

### DIFF
--- a/Source/Library.cpp
+++ b/Source/Library.cpp
@@ -58,6 +58,8 @@ Library::Library(Database db)
                        QSettings::NativeFormat);
     QString steamPath = settings.value("SteamPath").toString();
     steamRoot = QDir(steamPath);
+
+    steamFound = steamRoot != QDir::currentPath();
 #elif defined(__APPLE__)
     // TODO: however OS X handles steam
     return;


### PR DESCRIPTION
Check if the steamRoot is the same as the currentDirectory, which occurs when the registry query returns a blank string.
