### PR TITLE
Fix case for SteamApps directory

### DIFF
--- a/Source/Library.cpp
+++ b/Source/Library.cpp
@@ -233,8 +233,14 @@ bool Library::isProcessRunning() const
 
 void Library::findSteamGames(QDir steamRoot)
 {
+
+    QDir steamAppsDir = steamRoot.filePath("steamapps");
+    if (!steamAppsDir.exists())
+    {
+        steamAppsDir = steamRoot.filePath("SteamApps");
+    }
     pt::ptree libraryFolders;
-    pt::read_info(steamRoot.filePath("steamapps/libraryfolders.vdf")
+    pt::read_info(steamAppsDir.filePath("libraryfolders.vdf")
                       .toLocal8Bit()
                       .constData(),
                   libraryFolders);
@@ -371,7 +377,15 @@ void Library::parseAcf()
     for (QString iter : steamDirectoryList)
     {
         QDir steamAppsDir(iter);
-        steamAppsDir = steamAppsDir.filePath("steamapps");
+        if (steamAppsDir.exists("SteamApps"))
+        {
+            steamAppsDir = steamAppsDir.filePath("SteamApps");
+        }
+        else
+        {
+            steamAppsDir = steamAppsDir.filePath("steamapps");
+        }
+
         QStringList fileList = steamAppsDir.entryList(
             QStringList("*.acf"), QDir::Files | QDir::NoSymLinks);
 


### PR DESCRIPTION
This fixes the case for steamapps directory, which causes an error on
Linux:

```
terminate called after throwing an instance of
'boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::property_tree::info_parser::info_parser_error> >'
  what():  /home/jan/.steam/steam/steamapps/libraryfolders.vdf: cannot
open file for reading
[1]    29125 abort (core dumped)  ProjectAscension
```

The correct filepath is:
 `~/.steam/steam/SteamApps/libraryfolders.vdf`
instead of:
 `~/.steam/steam/steamapps/libraryfolders.vdf`
