### PR TITLE
Mouse event fixes

### DIFF
--- a/Source/UnixWindow.cpp
+++ b/Source/UnixWindow.cpp
@@ -57,7 +57,7 @@ void UnixWindow::closeWindow()
 void UnixWindow::mousePressEvent(QMouseEvent* evt)
 {
     oldWindowPos = evt->globalPos();
-    if (evt->pos().y() < 70)
+    if (evt->pos().y() < 32)
     {
         dragging = true;
     }

--- a/Source/UnixWindow.cpp
+++ b/Source/UnixWindow.cpp
@@ -59,7 +59,21 @@ void UnixWindow::mousePressEvent(QMouseEvent* evt)
     oldWindowPos = evt->globalPos();
     if (evt->pos().y() < 32)
     {
-        dragging = true;
+        if (evt->button() == Qt::LeftButton)
+        {
+            dragging = true;
+        }
+    }
+}
+
+void UnixWindow::mouseDoubleClickEvent(QMouseEvent* evt)
+{
+    if (evt->pos().y() < 32)
+    {
+        if (evt->button() == Qt::LeftButton)
+        {
+            maximize();
+        }
     }
 }
 

--- a/Source/UnixWindow.h
+++ b/Source/UnixWindow.h
@@ -19,6 +19,7 @@ private:
     bool dragging;
 
     void mousePressEvent(QMouseEvent* evt);
+    void mouseDoubleClickEvent(QMouseEvent* evt);
     void mouseReleaseEvent(QMouseEvent* evt);
     void mouseMoveEvent(QMouseEvent* evt);
 };

--- a/Source/WinWindow.cpp
+++ b/Source/WinWindow.cpp
@@ -65,26 +65,29 @@ bool WinPanel::winEvent(MSG* message, long*)
 
 void WinWindow::mousePressEvent(QMouseEvent* event)
 {
-    if (event->button() == Qt::LeftButton)
-    {
-        ReleaseCapture();
-        SendMessage(windowHandle, WM_NCLBUTTONDOWN, HTCAPTION, 0);
-    }
-
-    if (event->type() == QEvent::MouseButtonDblClick)
+    if (event->pos().y() < 32)
     {
         if (event->button() == Qt::LeftButton)
         {
-            WINDOWPLACEMENT wp;
-            wp.length = sizeof(WINDOWPLACEMENT);
-            GetWindowPlacement(parentWindow(), &wp);
-            if (wp.showCmd == SW_MAXIMIZE)
+            ReleaseCapture();
+            SendMessage(windowHandle, WM_NCLBUTTONDOWN, HTCAPTION, 0);
+        }
+
+        if (event->type() == QEvent::MouseButtonDblClick)
+        {
+            if (event->button() == Qt::LeftButton)
             {
-                ShowWindow(parentWindow(), SW_RESTORE);
-            }
-            else
-            {
-                ShowWindow(parentWindow(), SW_MAXIMIZE);
+                WINDOWPLACEMENT wp;
+                wp.length = sizeof(WINDOWPLACEMENT);
+                GetWindowPlacement(parentWindow(), &wp);
+                if (wp.showCmd == SW_MAXIMIZE)
+                {
+                    ShowWindow(parentWindow(), SW_RESTORE);
+                }
+                else
+                {
+                    ShowWindow(parentWindow(), SW_MAXIMIZE);
+                }
             }
         }
     }


### PR DESCRIPTION
These were a few local changes I had left-over - adjusts mouse event capture to within the range of the window control bar, and enforces left-click dragging on Unix. Also overrides the double-click event to maximize the Unix window.
