### PR TITLE
Init settings and fonts before setting stylesheet

### DIFF
--- a/src/gui/stack/news.cpp
+++ b/src/gui/stack/news.cpp
@@ -67,7 +67,6 @@ void News::onRSSReturned(QNetworkReply* reply)
                 {
                     QString title = xml.readElementText();
                     newsFeedWidget->setRSSTitle(title);
-                    //rss->beginGroup("feeds");
                     if (!rss->contains(title))
                     {
                         qDebug() << title;
@@ -80,17 +79,17 @@ void News::onRSSReturned(QNetworkReply* reply)
                 QString url;
                 QString title;
                 xml.readNext();
-                if(xml.name() == "title")title = xml.readElementText();
+                if(xml.name() == "title")
+                {
+                    title = xml.readElementText();
+                }
                 xml.readNext();
-                if(xml.name() == "link")url = xml.readElementText();
+                if(xml.name() == "link")
+                {
+                    url = xml.readElementText();
+                }
                 newsFeedWidget->addRSSItem(title, url);
             }
-            /*if(xml.name() == "link")
-            {
-                //xml.readNext();
-                qDebug() << xml.readElementText();
-                //newsFeedWidget->addRSSItem(xml.readElementText());
-            }*/
         }
         xml.readNext();
     }
@@ -104,7 +103,6 @@ void News::saveFeeds(QString title, QString url)
     qDebug() << "Saving rss feed" << title << url;
     if (rss->isWritable())
     {
-        //rss->beginGroup("feeds");
         rss->setValue(title, url);
     }
     qDebug() << rss->allKeys();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,9 @@ int main(int argc, char* argv[])
         application->setWindowIcon(QIcon(":/system_menu/icons/ascension_icon.ico"));
     #endif
 
+    initSettings(*application);
+    initFonts(*application);
+
     // Global stylesheet
     QFile stylesheet(":/styles/pa_client.css");
     if (stylesheet.open(QFile::ReadOnly))
@@ -30,9 +33,6 @@ int main(int argc, char* argv[])
         QString styleSheet = stylesheet.readAll();
         application->setStyleSheet(styleSheet + getConfigurableStyle());
     }
-
-    initSettings(*application);
-    initFonts(*application);
 
     #ifdef Q_OS_WIN
         // Background color


### PR DESCRIPTION
Fixes bug on first run where buttons would not have the proper styling, as the default palette was not initialized yet.
