### PR TITLE
Fix Origin Finding Bug

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -95,6 +95,7 @@ if(WIN32)
         source_group("src\\gui\\borderless\\" FILES ${GUI_BORDERLESS})
         source_group("src\\gui\\stack\\" FILES ${GUI_STACK})
         source_group("src\\gui\\wizards\\" FILES ${GUI_WIZARDS})
+        source_group("src\\gui\\dialogs\\" FILES ${GUI_DIALOGS})
     endif()
 elseif(UNIX)
     set(GUI_CORE ${GUI_CORE}

--- a/src/drm/origin_drm.cpp
+++ b/src/drm/origin_drm.cpp
@@ -16,11 +16,11 @@ void OriginDRM::checkOriginExists()
     originRoot = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation).append("/Origin/");
 #endif
 
-    if (QDir(originRoot.filePath("local.xml")).exists())
+    if (originRoot.exists("local.xml"))
     {
+        qDebug() << originRoot.filePath("local.xml");
         pt::ptree originTree;
         read_xml(originRoot.filePath("local.xml").toLocal8Bit().constData(), originTree);
-
 
         for (auto &xmlIter : originTree.get_child("Settings"))
         {

--- a/src/drm/steam_drm.cpp
+++ b/src/drm/steam_drm.cpp
@@ -35,7 +35,7 @@ void SteamDRM::checkExists()
         steamAppsDir = steamFolder.filePath("SteamApps");
     }
 
-    if (QFile(steamAppsDir.filePath("libraryFolders.vdf")).exists() && steamFolder.filePath("").trimmed() != "" && steamFolder.exists() && steamFolder != QDir("."))
+    if (steamAppsDir.exists("libraryFolders.vdf") && steamFolder.filePath("").trimmed() != "" && steamFolder.exists() && steamFolder != QDir("."))
     {
         this->setRootDir(steamFolder);
         this->setIsInstalled();


### PR DESCRIPTION
Uses QDir::exists(filepath) to check if a file exists instead of creating a new QFile/QDir object to run the exists method.
